### PR TITLE
Use static verifySignedWithPublicKey for inbox ownership verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@atproto/oauth-types": "^0.6.2",
     "@tanstack/react-virtual": "^3.13.18",
     "@xmtp/browser-sdk": "6.2.0",
+    "@xmtp/wasm-bindings": "^1.9.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "viem": "^2.23.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@xmtp/browser-sdk':
         specifier: 6.2.0
         version: 6.2.0
+      '@xmtp/wasm-bindings':
+        specifier: ^1.9.1
+        version: 1.9.1
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -1754,7 +1757,7 @@ packages:
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -2691,7 +2694,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}

--- a/src/services/xmtp.ts
+++ b/src/services/xmtp.ts
@@ -11,6 +11,9 @@ import {
   ConversationType,
   ConsentState
 } from '@xmtp/browser-sdk'
+import {
+  verifySignedWithPublicKey as verifySignedWithPublicKeyBinding
+} from '@xmtp/wasm-bindings'
 
 // Use production network for built distributions, dev for development
 const XMTP_ENV = import.meta.env.MODE === 'production' ? 'production' : 'dev'
@@ -859,19 +862,13 @@ function base64ToUint8Array(base64: string): Uint8Array {
 /**
  * Verify that a signature was created by an installation key belonging to the given inbox.
  * Used to verify the cryptographic binding between a Bluesky DID and XMTP inbox.
- * Requires an initialized client to verify signatures.
+ * Uses static verification - no client instance required.
  */
 export async function verifyInboxOwnership(
   inboxId: string,
   did: string,
   signature: string
 ): Promise<boolean> {
-  const client = xmtpService.getClient()
-  if (!client) {
-    verboseWarn('Cannot verify inbox ownership: XMTP client not initialized')
-    return false
-  }
-
   verboseLog('Verifying inbox ownership:', { inboxId: inboxId.slice(0, 16) + '...', did })
 
   try {
@@ -889,13 +886,12 @@ export async function verifyInboxOwnership(
     for (let i = 0; i < inboxState.installations.length; i++) {
       const installation = inboxState.installations[i]
       try {
-        const isValid = await client.verifySignedWithPublicKey(did, signatureBytes, installation.bytes)
-        if (isValid) {
-          verboseLog(`Signature verified by installation ${i}`)
-          return true
-        }
-      } catch (verifyError) {
-        verboseLog(`Installation ${i} verify error:`, verifyError)
+        // Use static verification from wasm-bindings (throws on invalid)
+        verifySignedWithPublicKeyBinding(did, signatureBytes, installation.bytes)
+        verboseLog(`Signature verified by installation ${i}`)
+        return true
+      } catch {
+        // Signature didn't match this installation, try next
       }
     }
     verboseWarn('No installation could verify the signature')


### PR DESCRIPTION
## Summary
- Import `verifySignedWithPublicKey` directly from `@xmtp/wasm-bindings` instead of using the instance method on Client
- Remove the requirement for an initialized XMTP client when verifying signatures
- Verification is a pure cryptographic operation that doesn't need client state

## Test plan
- [ ] Verify identity binding still works correctly when publishing to ATProto
- [ ] Verify signature verification works when resolving DIDs to inbox IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)