### PR TITLE
Verify inbox ownership for records from indexer

### DIFF
--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -1,4 +1,5 @@
 import { identityService } from './identity'
+import { verifyInboxOwnership } from './xmtp'
 
 const JETSTREAM_URL = 'wss://jetstream2.us-west.bsky.network/subscribe'
 const INDEXER_CACHE_KEY = 'jetstream-indexer-cache'
@@ -97,7 +98,9 @@ class IndexerService {
     this.ws.onmessage = (event) => {
       try {
         const evt: JetstreamEvent = JSON.parse(event.data)
-        this.handleEvent(evt)
+        this.handleEvent(evt).catch((error) => {
+          console.error('Failed to handle Jetstream event:', error)
+        })
       } catch (error) {
         console.error('Failed to parse Jetstream event:', error)
       }
@@ -130,7 +133,7 @@ class IndexerService {
     }, delay)
   }
 
-  private handleEvent(evt: JetstreamEvent): void {
+  private async handleEvent(evt: JetstreamEvent): Promise<void> {
     if (evt.kind !== 'commit' || !evt.commit) {
       return
     }
@@ -143,8 +146,17 @@ class IndexerService {
     }
 
     if (operation === 'create' || operation === 'update') {
-      if (record?.id) {
+      if (record?.id && record?.verificationSignature) {
         const inboxId = record.id
+        const signature = record.verificationSignature
+
+        // Verify inbox ownership before adding to mapping
+        const isValid = await verifyInboxOwnership(inboxId, did, signature)
+        if (!isValid) {
+          console.warn(`Rejected unverified org.xmtp.inbox record: ${did} -> ${inboxId.slice(0, 16)}...`)
+          return
+        }
+
         console.log(`Indexed org.xmtp.inbox: ${did} -> ${inboxId}`)
 
         this.inboxToDid.set(inboxId, did)


### PR DESCRIPTION
## Summary
- Adds `verifyInboxOwnership` call before accepting org.xmtp.inbox records from Jetstream
- Records that fail signature verification are rejected with a warning log
- Prevents malicious or invalid records from being added to the inbox-to-DID mapping

## Test plan
- [ ] Connect to Jetstream and verify valid records are still indexed
- [ ] Confirm rejected records show warning in console
- [ ] Verify existing functionality (lookups, caching) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)