### PR TITLE
Refactor lookupInboxForDid to distinguish between 404s and network errors

### DIFF
--- a/src/components/chat/new-conversation/NewConversationProviderBridge.tsx
+++ b/src/components/chat/new-conversation/NewConversationProviderBridge.tsx
@@ -81,10 +81,10 @@ export function NewConversationProviderBridge({ children, onClose }: NewConversa
 
     try {
       // Step 1: Check if user has published an XMTP record
-      const record = await identityService.lookupInboxForDid(user.did)
+      const result = await identityService.lookupInboxForDid(user.did)
 
-      if (!record) {
-        // No record = not on XMTP, no need to verify anything
+      if (!result.found) {
+        // No record = not on XMTP (or lookup failed), no need to verify anything
         const status: XmtpUserStatus = 'not-on-chat'
         if (xmtpStatusCache.size >= XMTP_STATUS_CACHE_MAX_SIZE) {
           const oldestKey = xmtpStatusCache.keys().next().value
@@ -98,9 +98,9 @@ export function NewConversationProviderBridge({ children, onClose }: NewConversa
       // Step 2: User is on XMTP - now verify their signature
       // (don't trust local cache - signature could have changed)
       const isValid = await identityService.verifyIdentityBinding(
-        record.inboxId,
+        result.inboxId,
         user.did,
-        record.verificationSignature
+        result.verificationSignature
       )
       const status: XmtpUserStatus = isValid ? 'verified' : 'unverified'
 

--- a/src/components/profile/UserProfileModal.tsx
+++ b/src/components/profile/UserProfileModal.tsx
@@ -86,9 +86,9 @@ export function UserProfileModal() {
       try {
         // Always fetch fresh from ATProto and verify signature
         // (don't trust local cache - signature could have changed)
-        const record = await identityService.lookupInboxForDid(viewingProfileDid!)
-        if (!record) {
-          // No record published
+        const result = await identityService.lookupInboxForDid(viewingProfileDid!)
+        if (!result.found) {
+          // No record published (or lookup failed)
           if (isOwnProfile && isXMTPConnected) {
             // Own profile with no published record - still "available" locally
             setXmtpStatus('available')
@@ -100,18 +100,18 @@ export function UserProfileModal() {
 
         // Verify the signature
         const isValid = await identityService.verifyIdentityBinding(
-          record.inboxId,
+          result.inboxId,
           viewingProfileDid!,
-          record.verificationSignature
+          result.verificationSignature
         )
 
         if (isValid) {
-          setInboxId(record.inboxId)
+          setInboxId(result.inboxId)
           setXmtpStatus('available')
         } else {
           // Has record but verification failed
           console.warn('Identity verification failed for', viewingProfileDid)
-          setInboxId(record.inboxId)
+          setInboxId(result.inboxId)
           setXmtpStatus('unverified')
         }
       } catch (err) {

--- a/src/components/settings/variants/DevTools.tsx
+++ b/src/components/settings/variants/DevTools.tsx
@@ -48,8 +48,8 @@ export function DevTools() {
     if (!blueskyProfile?.did || !showDevTools) return
 
     identityService.lookupInboxForDid(blueskyProfile.did)
-      .then(record => {
-        setAtprotoRecord(record ? { inboxId: record.inboxId, signature: record.verificationSignature } : null)
+      .then(result => {
+        setAtprotoRecord(result.found ? { inboxId: result.inboxId, signature: result.verificationSignature } : null)
       })
       .catch(() => setAtprotoRecord(null))
   }, [blueskyProfile?.did, showDevTools, buildMode])
@@ -79,8 +79,8 @@ export function DevTools() {
     if (!blueskyProfile?.did) return
     setAtprotoRecord('loading')
     try {
-      const record = await identityService.lookupInboxForDid(blueskyProfile.did)
-      setAtprotoRecord(record ? { inboxId: record.inboxId, signature: record.verificationSignature } : null)
+      const result = await identityService.lookupInboxForDid(blueskyProfile.did)
+      setAtprotoRecord(result.found ? { inboxId: result.inboxId, signature: result.verificationSignature } : null)
     } catch {
       setAtprotoRecord(null)
     }

--- a/src/services/identity.test.ts
+++ b/src/services/identity.test.ts
@@ -282,6 +282,21 @@ describe('IdentityService', () => {
       expect(identityService.getDidFromInboxId('inbox-stale')).toBeUndefined()
     })
 
+    it('should return null but preserve cache on network error', async () => {
+      // Pre-populate cache with mapping
+      identityService.registerIndexedMapping('inbox-cached', 'did:plc:cached')
+      expect(identityService.getDidFromInboxId('inbox-cached')).toBe('did:plc:cached')
+
+      // Mock network failure
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      const inboxId = await identityService.resolveDidToInbox('did:plc:cached')
+
+      expect(inboxId).toBeNull()
+      // Cache should be preserved since this was a network error, not a 404
+      expect(identityService.getDidFromInboxId('inbox-cached')).toBe('did:plc:cached')
+    })
+
     it('should return null when signature verification fails', async () => {
       // Mock fetch with valid response
       global.fetch = vi.fn().mockResolvedValue({

--- a/src/services/identity.ts
+++ b/src/services/identity.ts
@@ -137,8 +137,17 @@ class IdentityService {
   /**
    * Lookup the XMTP inbox record for a given DID from ATProto.
    * Fetches the org.xmtp.inbox record from the user's PDS.
+   *
+   * Returns:
+   * - { found: true, inboxId, verificationSignature } on success
+   * - { found: false, notFound: true } when record doesn't exist (404)
+   * - { found: false, notFound: false } on network/other errors
    */
-  async lookupInboxForDid(did: string): Promise<{ inboxId: string; verificationSignature: string } | null> {
+  async lookupInboxForDid(
+    did: string
+  ): Promise<
+    { found: true; inboxId: string; verificationSignature: string } | { found: false; notFound: boolean }
+  > {
     try {
       // Use public API to fetch the record
       const response = await fetch(
@@ -147,9 +156,10 @@ class IdentityService {
 
       if (!response.ok) {
         if (response.status === 404) {
-          return null // Record doesn't exist
+          return { found: false, notFound: true }
         }
-        throw new Error(`Failed to fetch record: ${response.status}`)
+        console.error(`Failed to fetch record: ${response.status}`)
+        return { found: false, notFound: false }
       }
 
       const data = await response.json()
@@ -157,16 +167,17 @@ class IdentityService {
 
       if (!record.id || !record.verificationSignature) {
         console.warn('Invalid org.xmtp.inbox record:', record)
-        return null
+        return { found: false, notFound: true } // Treat invalid records as not found
       }
 
       return {
+        found: true,
         inboxId: record.id,
         verificationSignature: record.verificationSignature
       }
     } catch (error) {
       console.error('Failed to lookup inbox for DID:', error)
-      return null
+      return { found: false, notFound: false }
     }
   }
 
@@ -238,27 +249,29 @@ class IdentityService {
     }
 
     // Always fetch and verify from ATProto for other users
-    const record = await this.lookupInboxForDid(did)
-    if (!record) {
-      // User has no org.xmtp.inbox record - remove stale cache if present
-      const staleInbox = this.didToInbox.get(did)
-      if (staleInbox) {
-        this.unregisterIndexedMapping(did)
+    const result = await this.lookupInboxForDid(did)
+    if (!result.found) {
+      // Only clear cache on explicit 404 (record deleted), not on network errors
+      if (result.notFound) {
+        const staleInbox = this.didToInbox.get(did)
+        if (staleInbox) {
+          this.unregisterIndexedMapping(did)
+        }
       }
       return null
     }
 
     // Verify the signature
-    const isValid = await this.verifyIdentityBinding(record.inboxId, did, record.verificationSignature)
+    const isValid = await this.verifyIdentityBinding(result.inboxId, did, result.verificationSignature)
     if (!isValid) {
       console.warn('Identity binding verification failed for DID:', did)
       return null
     }
 
     // Update cache with verified mapping
-    this.registerIndexedMapping(record.inboxId, did)
+    this.registerIndexedMapping(result.inboxId, did)
 
-    return record.inboxId
+    return result.inboxId
   }
 
   /**

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -32,7 +32,7 @@ vi.mock('../services/identity', () => ({
     cacheProfile: vi.fn(),
     linkIdentity: vi.fn().mockResolvedValue(undefined),
     publishIdentityToATProto: vi.fn().mockResolvedValue(undefined),
-    lookupInboxForDid: vi.fn().mockResolvedValue(null),
+    lookupInboxForDid: vi.fn().mockResolvedValue({ found: false, notFound: true }),
     verifyIdentityBinding: vi.fn().mockResolvedValue(true),
     clearProfileCache: vi.fn()
   }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -211,7 +211,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         verboseLog('Checking for existing org.xmtp.inbox record...')
         const existingBinding = await identityService.lookupInboxForDid(blueskyProfile.did)
 
-        if (existingBinding) {
+        if (existingBinding.found) {
           verboseLog('Found existing record with inboxId:', existingBinding.inboxId)
 
           // Check if the existing record matches our current inbox
@@ -442,10 +442,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
 
     try {
-      const record = await identityService.lookupInboxForDid(blueskyProfile.did)
+      const result = await identityService.lookupInboxForDid(blueskyProfile.did)
 
-      if (!record) {
-        // No published record
+      if (!result.found) {
+        // No published record (or lookup failed)
         set({
           identityMismatch: false,
           signatureInvalid: false,
@@ -454,12 +454,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         return
       }
 
-      if (record.inboxId !== xmtpInboxId) {
+      if (result.inboxId !== xmtpInboxId) {
         // Different inbox published
         set({
           identityMismatch: true,
           signatureInvalid: false,
-          publishedInboxId: record.inboxId,
+          publishedInboxId: result.inboxId,
           mismatchDismissed: false
         })
         return
@@ -467,15 +467,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       // Same inbox - verify signature
       const isValid = await identityService.verifyIdentityBinding(
-        record.inboxId,
+        result.inboxId,
         blueskyProfile.did,
-        record.verificationSignature
+        result.verificationSignature
       )
 
       set({
         identityMismatch: false,
         signatureInvalid: !isValid,
-        publishedInboxId: record.inboxId,
+        publishedInboxId: result.inboxId,
         ...(!isValid && { mismatchDismissed: false })
       })
     } catch (error) {


### PR DESCRIPTION
## Summary
Refactored the `lookupInboxForDid` method to return a discriminated union type that distinguishes between three states: successful lookup, explicit 404 (record not found), and network/other errors. This allows callers to make more informed decisions about cache invalidation and error handling.

## Key Changes
- **Return type change**: `lookupInboxForDid` now returns `{ found: true; inboxId; verificationSignature } | { found: false; notFound: boolean }` instead of `{ inboxId; verificationSignature } | null`
  - `found: true` - Record successfully retrieved
  - `found: false, notFound: true` - Record doesn't exist (404)
  - `found: false, notFound: false` - Network or other errors

- **Cache preservation on network errors**: Updated `resolveDidToInbox` to only clear cached mappings on explicit 404s, preserving stale cache during transient network failures

- **Updated all call sites**: Modified 5 files to handle the new return type:
  - `NewConversationProviderBridge.tsx`
  - `UserProfileModal.tsx`
  - `DevTools.tsx`
  - `authStore.ts`
  - Test files updated accordingly

## Implementation Details
- The method now explicitly handles three HTTP response scenarios: 200 (success), 404 (not found), and other errors
- Invalid records (missing required fields) are treated as "not found" rather than network errors
- Error messages are logged but don't throw, allowing graceful degradation
- Cache invalidation logic is now more nuanced: only removes mappings when we're certain the record was deleted (404), not when we can't reach the server

https://claude.ai/code/session_01STkT64N1kaexbqPuKBPsJc