### PR TITLE
Fix WASM dual instance conflict with resolve.dedupe

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -41,11 +41,14 @@ export default defineConfig({
     resolve: {
       alias: {
         '@': resolve(__dirname, 'src')
-      }
+      },
+      // Ensure single instance of wasm-bindings to avoid WASM conflicts
+      dedupe: ['@xmtp/wasm-bindings']
     },
     optimizeDeps: {
       // XMTP browser SDK uses web workers that Vite's optimizer can't handle
-      exclude: ['@xmtp/browser-sdk']
+      // wasm-bindings must also be excluded to preserve WASM loading
+      exclude: ['@xmtp/browser-sdk', '@xmtp/wasm-bindings']
     }
   }
 })


### PR DESCRIPTION
## Summary
- Add `@xmtp/wasm-bindings` to `resolve.dedupe` to ensure single WASM instance
- Add `@xmtp/wasm-bindings` to `optimizeDeps.exclude` to preserve WASM loading

This fixes the "closure invoked recursively or after being dropped" error that occurs when importing `verifySignedWithPublicKey` directly from `@xmtp/wasm-bindings` while also using `@xmtp/browser-sdk` (which internally depends on wasm-bindings).

## Test plan
- [x] Verified app starts without WASM errors
- [x] Verified identity verification still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)