### PR TITLE
fix: add rate limiting to health check endpoint

### DIFF
--- a/packages/mapping-service/src/index.ts
+++ b/packages/mapping-service/src/index.ts
@@ -20,6 +20,7 @@ app.use('*', cors())
 app.use('/v1/lookup/*', rateLimit())
 app.use('/v1/bulk', rateLimit())
 app.use('/v1/register', rateLimit())
+app.use('/health', rateLimit())
 
 // Admin endpoints - 100 requests/minute (stricter) + auth check in admin router
 app.use('/v1/admin', adminRateLimit())


### PR DESCRIPTION
## Summary
- Adds rate limiting to `/health` endpoint to prevent abuse

## Test plan
- [ ] Deploy to staging and verify health endpoint respects rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)