### PR TITLE
feat: enable prerelease updates in auto-updater

### DIFF
--- a/electron/services/updater.ts
+++ b/electron/services/updater.ts
@@ -55,6 +55,8 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
   // Disable auto-download - let user choose when to download
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
+  // Allow prerelease/beta updates
+  autoUpdater.allowPrerelease = true
 
   // Forward events to renderer
   autoUpdater.on('checking-for-update', () => {


### PR DESCRIPTION
## Summary
- Enable `allowPrerelease = true` in electron-updater so users on stable versions can receive beta updates
- Fixes issue where users running 1.0.3 weren't seeing 1.0.4-beta.x updates

## Test plan
- [ ] Build and verify auto-updater detects beta releases
- [ ] Verify users on stable versions receive beta update notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)