### PR TITLE
feat: integrate XMTP native consent system

### DIFF
--- a/src/components/chat/RequestsView.tsx
+++ b/src/components/chat/RequestsView.tsx
@@ -7,12 +7,16 @@ interface RequestsViewProps {
 }
 
 export function RequestsView({ onClose }: RequestsViewProps) {
-  const { requests, select, acceptRequest } = useConversations()
+  const { requests, select, acceptRequest, denyRequest } = useConversations()
 
   const handleAccept = (conversationId: string) => {
     acceptRequest(conversationId)
     select(conversationId)
     onClose()
+  }
+
+  const handleBlock = (conversationId: string) => {
+    denyRequest(conversationId)
   }
 
   const handleView = (conversationId: string) => {
@@ -80,6 +84,7 @@ export function RequestsView({ onClose }: RequestsViewProps) {
                   conversation={conversation}
                   onAccept={() => handleAccept(conversation.id)}
                   onView={() => handleView(conversation.id)}
+                  onBlock={() => handleBlock(conversation.id)}
                 />
               ))}
             </div>
@@ -94,9 +99,10 @@ interface RequestItemProps {
   conversation: ChatConversation
   onAccept: () => void
   onView: () => void
+  onBlock: () => void
 }
 
-function RequestItem({ conversation, onAccept, onView }: RequestItemProps) {
+function RequestItem({ conversation, onAccept, onView, onBlock }: RequestItemProps) {
   const displayName = conversation.isGroup
     ? conversation.groupName || 'Group Chat'
     : conversation.peerProfile?.displayName ||
@@ -158,6 +164,12 @@ function RequestItem({ conversation, onAccept, onView }: RequestItemProps) {
               className="flex-1 py-2 px-4 bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] text-[var(--color-text-primary)] text-[13px] font-medium rounded-full transition-all duration-200 border border-[var(--color-border)]"
             >
               View
+            </button>
+            <button
+              onClick={onBlock}
+              className="py-2 px-4 text-red-500 hover:bg-red-500/10 text-[13px] font-medium rounded-full transition-all duration-200"
+            >
+              Block
             </button>
           </div>
         </div>

--- a/src/components/conversation/ConversationProviderBridge.tsx
+++ b/src/components/conversation/ConversationProviderBridge.tsx
@@ -20,7 +20,7 @@ export function ConversationProviderBridge({
   searchQuery = '',
   onSearchChange
 }: ConversationProviderBridgeProps) {
-  const { primary, requests, requestCount, selectedId, isLoading, select, acceptRequest } = useConversations()
+  const { primary, requests, requestCount, selectedId, isLoading, select, acceptRequest, denyRequest } = useConversations()
 
   const conversations = filter === 'requests' ? requests : primary
 
@@ -58,13 +58,14 @@ export function ConversationProviderBridge({
     actions: {
       select,
       search: handleSearch,
-      acceptRequest
+      acceptRequest,
+      denyRequest
     },
     meta: {
       isLoading,
       requestCount
     }
-  }), [filteredConversations, selectedId, filter, searchQuery, select, handleSearch, acceptRequest, isLoading, requestCount])
+  }), [filteredConversations, selectedId, filter, searchQuery, select, handleSearch, acceptRequest, denyRequest, isLoading, requestCount])
 
   return (
     <ConversationProvider value={contextValue}>

--- a/src/components/conversation/context/ConversationContext.ts
+++ b/src/components/conversation/context/ConversationContext.ts
@@ -13,6 +13,7 @@ export interface ConversationActions {
   select: (id: string) => void
   search: (query: string) => void
   acceptRequest: (id: string) => void
+  denyRequest: (id: string) => void
 }
 
 export interface ConversationMeta {

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -1,6 +1,5 @@
 import { useMemo, useCallback } from 'react'
 import { useChatStore } from '../stores/chatStore'
-import { useProfileStore } from '../stores/profileStore'
 import type { ChatConversation } from '../types'
 
 export function useConversations() {
@@ -12,38 +11,14 @@ export function useConversations() {
     selectConversation,
     loadConversations,
     markAsRead,
-    acceptedRequests,
     acceptRequest,
-    initiatedConversations
+    denyRequest
   } = useChatStore()
-
-  const { followingDids } = useProfileStore()
 
   // Check if a conversation should be in primary inbox
   const isPrimaryConversation = useCallback((conv: ChatConversation): boolean => {
-    // If we initiated this conversation, it's primary
-    if (initiatedConversations.has(conv.id)) return true
-
-    // If we explicitly accepted this request, it's primary
-    if (acceptedRequests.has(conv.id)) return true
-
-    // If we don't have following data yet, show all in primary (better UX than empty inbox)
-    if (followingDids.size === 0) return true
-
-    // For DMs: peer must be someone we follow
-    if (!conv.isGroup) {
-      const peerDid = conv.peerProfile?.did
-      if (peerDid && followingDids.has(peerDid)) return true
-      // If no peer profile/DID, put in primary (can't determine)
-      if (!peerDid) return true
-      return false
-    }
-
-    // For groups: at least one member (other than us) must be someone we follow
-    // Since we don't have member DIDs easily available, put groups in primary for now
-    // TODO: Implement proper group member DID resolution
-    return true
-  }, [initiatedConversations, acceptedRequests, followingDids])
+    return conv.consentState === 'allowed'
+  }, [])
 
   // Sort conversations by last message time (unread first)
   const sortedConversations = useMemo(() => {
@@ -84,6 +59,7 @@ export function useConversations() {
     select: selectConversation,
     refresh: loadConversations,
     markAsRead,
-    acceptRequest
+    acceptRequest,
+    denyRequest
   }
 }

--- a/src/services/xmtp.ts
+++ b/src/services/xmtp.ts
@@ -845,11 +845,17 @@ class XMTPService {
     await this.client.revokeAllOtherInstallations()
     verboseLog('All other installations revoked')
   }
+
+  async setConsentState(conversationId: string, state: ConsentState): Promise<void> {
+    const conv = await this.getConversation(conversationId)
+    if (!conv) throw new Error('Conversation not found')
+    await conv.updateConsentState(state)
+  }
 }
 
 export const xmtpService = new XMTPService()
 export type { XMTPConversation, GroupMember }
-export { Client }
+export { Client, ConsentState }
 
 /**
  * Convert base64 string to Uint8Array (browser-compatible)

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -17,13 +17,20 @@ vi.mock('../services/xmtp', () => ({
     getGroupImageUrl: vi.fn().mockReturnValue(undefined),
     isGroup: vi.fn().mockReturnValue(false),
     streamMessages: vi.fn(),
-    stopStreaming: vi.fn()
+    stopStreaming: vi.fn(),
+    setConsentState: vi.fn().mockResolvedValue(undefined)
+  },
+  ConsentState: {
+    Allowed: 1,
+    Denied: 2,
+    Unknown: 0
   }
 }))
 
 vi.mock('../services/bluesky', () => ({
   blueskyService: {
-    getProfile: vi.fn()
+    getProfile: vi.fn(),
+    getDid: vi.fn().mockReturnValue(undefined)
   }
 }))
 
@@ -32,7 +39,15 @@ vi.mock('../services/identity', () => ({
     getAddressFromDid: vi.fn(),
     getDidFromInboxId: vi.fn().mockReturnValue(undefined),
     getCachedProfile: vi.fn().mockReturnValue(undefined),
-    cacheProfile: vi.fn()
+    cacheProfile: vi.fn(),
+    registerIndexedMapping: vi.fn(),
+    bulkResolveInboxToDid: vi.fn().mockResolvedValue(new Map())
+  }
+}))
+
+vi.mock('./profileStore', () => ({
+  useProfileStore: {
+    getState: vi.fn().mockReturnValue({ followingDids: new Set() })
   }
 }))
 
@@ -59,9 +74,7 @@ describe('ChatStore', () => {
       isCreating: false,
       isSending: false,
       error: null,
-      unreadTotal: 0,
-      acceptedRequests: new Set(),
-      initiatedConversations: new Set()
+      unreadTotal: 0
     })
   })
 
@@ -80,11 +93,12 @@ describe('ChatStore', () => {
   })
 
   describe('loadConversations', () => {
-    it('should load and transform conversations', async () => {
+    it('should load and transform conversations with consent state', async () => {
       const mockConversations = [
         {
           id: 'conv-1',
           metadata: {},
+          consentState: vi.fn().mockResolvedValue(1), // ConsentState.Allowed
           lastMessage: vi.fn().mockResolvedValue({ content: 'Hello', sentAtNs: BigInt(1000000000) })
         }
       ]
@@ -103,7 +117,38 @@ describe('ChatStore', () => {
       expect(state.conversations.length).toBe(1)
       expect(state.conversations[0].id).toBe('conv-1')
       expect(state.conversations[0].isGroup).toBe(false)
+      expect(state.conversations[0].consentState).toBe('allowed')
       expect(state.isLoadingConversations).toBe(false)
+    })
+
+    it('should filter out denied conversations', async () => {
+      const mockConversations = [
+        {
+          id: 'conv-allowed',
+          metadata: {},
+          consentState: vi.fn().mockResolvedValue(1), // Allowed
+          lastMessage: vi.fn().mockResolvedValue(null)
+        },
+        {
+          id: 'conv-denied',
+          metadata: {},
+          consentState: vi.fn().mockResolvedValue(2), // Denied
+          lastMessage: vi.fn().mockResolvedValue(null)
+        }
+      ]
+
+      vi.mocked(xmtpService.getConversations).mockResolvedValueOnce(mockConversations as any)
+      vi.mocked(xmtpService.getMembers).mockResolvedValue([
+        { inboxId: 'my-inbox-id' },
+        { inboxId: 'peer-inbox-id' }
+      ] as any)
+
+      const { loadConversations } = useChatStore.getState()
+      await loadConversations()
+
+      const state = useChatStore.getState()
+      expect(state.conversations.length).toBe(1)
+      expect(state.conversations[0].id).toBe('conv-allowed')
     })
 
     it('should handle errors', async () => {
@@ -189,7 +234,7 @@ describe('ChatStore', () => {
       useChatStore.setState({
         selectedConversationId: 'conv-1',
         conversations: [
-          { id: 'conv-1', topic: 'topic-1', peerAddress: '0x1', unreadCount: 0, isGroup: false }
+          { id: 'conv-1', topic: 'topic-1', peerAddress: '0x1', unreadCount: 0, isGroup: false, consentState: 'allowed' }
         ]
       })
 
@@ -204,7 +249,7 @@ describe('ChatStore', () => {
   })
 
   describe('createDm', () => {
-    it('should create DM and add to conversations', async () => {
+    it('should create DM, set consent, and add to conversations', async () => {
       const mockConversation = { id: 'new-conv-1' }
       vi.mocked(xmtpService.createDm).mockResolvedValueOnce(mockConversation as any)
 
@@ -212,9 +257,11 @@ describe('ChatStore', () => {
       const convId = await createDm('peer-inbox-id')
 
       expect(convId).toBe('new-conv-1')
+      expect(xmtpService.setConsentState).toHaveBeenCalledWith('new-conv-1', 1) // ConsentState.Allowed
 
       const state = useChatStore.getState()
       expect(state.conversations.length).toBe(1)
+      expect(state.conversations[0].consentState).toBe('allowed')
       expect(state.selectedConversationId).toBe('new-conv-1')
     })
 
@@ -230,26 +277,77 @@ describe('ChatStore', () => {
   })
 
   describe('createGroup', () => {
-    it('should create group with members', async () => {
+    it('should create group with consent and members', async () => {
       const mockConversation = { id: 'group-conv-1' }
       vi.mocked(xmtpService.createGroup).mockResolvedValueOnce(mockConversation as any)
 
       const { createGroup } = useChatStore.getState()
-      // createGroup now accepts inbox IDs directly (not addresses)
       const convId = await createGroup(['inbox-1', 'inbox-2'], 'Test Group')
 
       expect(convId).toBe('group-conv-1')
+      expect(xmtpService.setConsentState).toHaveBeenCalledWith('group-conv-1', 1) // ConsentState.Allowed
 
       const state = useChatStore.getState()
       expect(state.conversations.length).toBe(1)
       expect(state.conversations[0].isGroup).toBe(true)
       expect(state.conversations[0].groupName).toBe('Test Group')
+      expect(state.conversations[0].consentState).toBe('allowed')
     })
 
     it('should handle no valid members', async () => {
       const { createGroup } = useChatStore.getState()
-      // Empty inbox IDs array should throw
       await expect(createGroup([], 'Test')).rejects.toThrow('No valid XMTP members')
+    })
+  })
+
+  describe('acceptRequest', () => {
+    it('should set consent to allowed and update conversation state', async () => {
+      useChatStore.setState({
+        conversations: [
+          { id: 'conv-1', topic: 't1', peerAddress: '0x1', unreadCount: 0, isGroup: false, consentState: 'unknown' }
+        ]
+      })
+
+      const { acceptRequest } = useChatStore.getState()
+      await acceptRequest('conv-1')
+
+      expect(xmtpService.setConsentState).toHaveBeenCalledWith('conv-1', 1) // ConsentState.Allowed
+      const state = useChatStore.getState()
+      expect(state.conversations[0].consentState).toBe('allowed')
+    })
+  })
+
+  describe('denyRequest', () => {
+    it('should set consent to denied and remove conversation', async () => {
+      useChatStore.setState({
+        conversations: [
+          { id: 'conv-1', topic: 't1', peerAddress: '0x1', unreadCount: 0, isGroup: false, consentState: 'unknown' },
+          { id: 'conv-2', topic: 't2', peerAddress: '0x2', unreadCount: 0, isGroup: false, consentState: 'allowed' }
+        ]
+      })
+
+      const { denyRequest } = useChatStore.getState()
+      await denyRequest('conv-1')
+
+      expect(xmtpService.setConsentState).toHaveBeenCalledWith('conv-1', 2) // ConsentState.Denied
+      const state = useChatStore.getState()
+      expect(state.conversations.length).toBe(1)
+      expect(state.conversations[0].id).toBe('conv-2')
+    })
+
+    it('should clear selection if denied conversation was selected', async () => {
+      useChatStore.setState({
+        conversations: [
+          { id: 'conv-1', topic: 't1', peerAddress: '0x1', unreadCount: 0, isGroup: false, consentState: 'unknown' }
+        ],
+        selectedConversationId: 'conv-1'
+      })
+
+      const { denyRequest } = useChatStore.getState()
+      await denyRequest('conv-1')
+
+      const state = useChatStore.getState()
+      expect(state.selectedConversationId).toBeNull()
     })
   })
 
@@ -257,8 +355,8 @@ describe('ChatStore', () => {
     it('should reset unread count for conversation', () => {
       useChatStore.setState({
         conversations: [
-          { id: 'conv-1', topic: 't1', peerAddress: '0x1', unreadCount: 5, isGroup: false },
-          { id: 'conv-2', topic: 't2', peerAddress: '0x2', unreadCount: 3, isGroup: false }
+          { id: 'conv-1', topic: 't1', peerAddress: '0x1', unreadCount: 5, isGroup: false, consentState: 'allowed' },
+          { id: 'conv-2', topic: 't2', peerAddress: '0x2', unreadCount: 3, isGroup: false, consentState: 'allowed' }
         ],
         unreadTotal: 8
       })

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand'
 import type { DecodedMessage } from '@xmtp/browser-sdk'
 import type { ChatConversation, ChatMessage, BlueskyProfile } from '../types'
-import { xmtpService } from '../services/xmtp'
+import { xmtpService, ConsentState } from '../services/xmtp'
 import { identityService } from '../services/identity'
 import { blueskyService } from '../services/bluesky'
+import { useProfileStore } from './profileStore'
 import { getErrorMessage } from '../utils/errors'
 
 // Module-level timeout for conversation stream debouncing (cleared on stop)
@@ -327,25 +328,6 @@ function addStreamedMessage(
   }
 }
 
-// Generic localStorage helpers for Set<string> persistence
-function loadStringSet(key: string): Set<string> {
-  try {
-    const stored = localStorage.getItem(key)
-    if (stored) return new Set(JSON.parse(stored))
-  } catch (error) {
-    console.error(`Failed to load ${key}:`, error)
-  }
-  return new Set()
-}
-
-function saveStringSet(key: string, items: Set<string>): void {
-  try {
-    localStorage.setItem(key, JSON.stringify([...items]))
-  } catch (error) {
-    console.error(`Failed to save ${key}:`, error)
-  }
-}
-
 // Get last known conversation count for a DID (used to skip skeleton loading for known-empty inboxes)
 export const getLastKnownConversationCount = (did: string): number | null => {
   try {
@@ -375,8 +357,6 @@ interface ChatState {
   isSending: boolean
   error: string | null
   unreadTotal: number
-  acceptedRequests: Set<string>
-  initiatedConversations: Set<string> // Conversations we started
 
   // Actions
   loadConversations: () => Promise<void>
@@ -389,7 +369,8 @@ interface ChatState {
   startConversationStream: () => Promise<void>
   stopStreaming: () => Promise<void>
   markAsRead: (conversationId: string) => void
-  acceptRequest: (conversationId: string) => void
+  acceptRequest: (conversationId: string) => Promise<void>
+  denyRequest: (conversationId: string) => Promise<void>
   clearError: () => void
   reset: () => void
 }
@@ -404,8 +385,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isSending: false,
   error: null,
   unreadTotal: 0,
-  acceptedRequests: loadStringSet('xmtp_accepted_requests'),
-  initiatedConversations: loadStringSet('xmtp_initiated_conversations'),
 
   loadConversations: async () => {
     const thisToken = Symbol()
@@ -418,21 +397,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const chatConversations: ChatConversation[] = []
       const myInboxId = xmtpService.getInboxId()
 
-      // Phase 1: Gather all conversation data and collect inbox IDs that need resolution
-      const allInboxIds = new Set<string>()
+      // Phase 1: Gather all conversation data and consent state
       interface ConvData {
         conv: typeof xmtpConversations[0]
         members: Awaited<ReturnType<typeof xmtpService.getMembers>>
         isGroup: boolean
         lastMessage: DecodedMessage | undefined
         peerInboxId: string | undefined
+        consentState: ConsentState
       }
       const convDatas: ConvData[] = []
 
       for (const conv of xmtpConversations) {
         const members = await xmtpService.getMembers(conv)
         const convIsGroup = xmtpService.isGroup(conv)
-        console.debug('[chatStore] Conversation', conv.id.slice(0, 8), 'isGroup:', convIsGroup, 'members:', members.length, 'metadata:', conv.metadata)
+        const consentState = await conv.consentState()
+        console.debug('[chatStore] Conversation', conv.id.slice(0, 8), 'isGroup:', convIsGroup, 'members:', members.length, 'consent:', consentState, 'metadata:', conv.metadata)
 
         const peerInboxId = !convIsGroup
           ? members.find((m) => m.inboxId !== myInboxId)?.inboxId
@@ -440,25 +420,42 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
         const lastMessage = (await conv.lastMessage()) ?? undefined
 
-        // Collect inbox IDs that need resolution
-        if (peerInboxId) allInboxIds.add(peerInboxId)
-        if (lastMessage && convIsGroup) {
-          for (const id of extractInboxIdsFromGroupUpdate(lastMessage.content)) {
-            allInboxIds.add(id)
-          }
-          if (lastMessage.senderInboxId) allInboxIds.add(lastMessage.senderInboxId)
-        }
-
-        convDatas.push({ conv, members, isGroup: convIsGroup, lastMessage, peerInboxId })
+        convDatas.push({ conv, members, isGroup: convIsGroup, lastMessage, peerInboxId, consentState })
       }
 
-      // Phase 2: Single bulk resolution for all inbox IDs
-      if (allInboxIds.size > 0) {
-        await ensureInboxIdsResolved([...allInboxIds])
+      // Filter out denied conversations before identity resolution
+      const activeConvDatas = convDatas.filter(d => d.consentState !== ConsentState.Denied)
+
+      // Phase 2: Single bulk resolution for all inbox IDs (only for active conversations)
+      const activeInboxIds = new Set<string>()
+      for (const d of activeConvDatas) {
+        if (d.peerInboxId) activeInboxIds.add(d.peerInboxId)
+        if (d.lastMessage && d.isGroup) {
+          for (const id of extractInboxIdsFromGroupUpdate(d.lastMessage.content)) {
+            activeInboxIds.add(id)
+          }
+          if (d.lastMessage.senderInboxId) activeInboxIds.add(d.lastMessage.senderInboxId)
+        }
+      }
+      if (activeInboxIds.size > 0) {
+        await ensureInboxIdsResolved([...activeInboxIds])
+      }
+
+      // Auto-allow unknown DMs from people the user follows on Bluesky
+      const { followingDids } = useProfileStore.getState()
+      if (followingDids.size > 0) {
+        for (const d of activeConvDatas) {
+          if (d.consentState !== ConsentState.Unknown || d.isGroup) continue
+          const peerDid = d.peerInboxId ? identityService.getDidFromInboxId(d.peerInboxId) : undefined
+          if (peerDid && followingDids.has(peerDid)) {
+            xmtpService.setConsentState(d.conv.id, ConsentState.Allowed).catch(() => {})
+            d.consentState = ConsentState.Allowed
+          }
+        }
       }
 
       // Phase 3: Build conversation objects with resolved names
-      for (const { conv, members, isGroup: convIsGroup, lastMessage, peerInboxId } of convDatas) {
+      for (const { conv, members, isGroup: convIsGroup, lastMessage, peerInboxId, consentState } of activeConvDatas) {
         let peerProfile: BlueskyProfile | undefined
 
         if (!convIsGroup && peerInboxId) {
@@ -491,7 +488,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
           groupName: xmtpService.getGroupName(conv) || undefined,
           groupDescription: xmtpService.getGroupDescription(conv) || undefined,
           groupImageUrl: xmtpService.getGroupImageUrl(conv) || undefined,
-          groupMembers: members.map((m) => m.inboxId)
+          groupMembers: members.map((m) => m.inboxId),
+          consentState: consentState === ConsentState.Allowed ? 'allowed' : 'unknown'
         })
       }
 
@@ -677,6 +675,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
     try {
       const conversation = await xmtpService.createDm(peerInboxId)
 
+      // Set consent to allowed for conversations we initiate
+      await xmtpService.setConsentState(conversation.id, ConsentState.Allowed)
+
       // Cache the peer's profile and register the inboxId -> DID mapping
       // This ensures we can resolve their profile when loading conversations later
       if (peerProfile) {
@@ -691,16 +692,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         peerAddress: peerInboxId, // Using inbox ID as the peer identifier
         peerProfile,
         unreadCount: 0,
-        isGroup: false
+        isGroup: false,
+        consentState: 'allowed'
       }
 
-      // Mark as initiated by us (so it shows in primary inbox)
-      const newInitiated = new Set(get().initiatedConversations)
-      newInitiated.add(conversation.id)
-      saveStringSet('xmtp_initiated_conversations', newInitiated)
-
       const conversations = [newConv, ...get().conversations]
-      set({ conversations, selectedConversationId: conversation.id, initiatedConversations: newInitiated })
+      set({ conversations, selectedConversationId: conversation.id })
 
       return conversation.id
     } catch (error) {
@@ -722,6 +719,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       const conversation = await xmtpService.createGroup(memberInboxIds, { name })
 
+      // Set consent to allowed for conversations we initiate
+      await xmtpService.setConsentState(conversation.id, ConsentState.Allowed)
+
       const newConv: ChatConversation = {
         id: conversation.id,
         topic: conversation.id,
@@ -729,16 +729,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         unreadCount: 0,
         isGroup: true,
         groupName: name,
-        groupMembers: memberInboxIds
+        groupMembers: memberInboxIds,
+        consentState: 'allowed'
       }
 
-      // Mark as initiated by us (so it shows in primary inbox)
-      const newInitiated = new Set(get().initiatedConversations)
-      newInitiated.add(conversation.id)
-      saveStringSet('xmtp_initiated_conversations', newInitiated)
-
       const conversations = [newConv, ...get().conversations]
-      set({ conversations, selectedConversationId: conversation.id, initiatedConversations: newInitiated })
+      set({ conversations, selectedConversationId: conversation.id })
 
       // Load messages so the system message ("you added X and Y") appears immediately
       get().loadMessages(conversation.id)
@@ -845,11 +841,30 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
-  acceptRequest: (conversationId: string) => {
-    const newAcceptedRequests = new Set(get().acceptedRequests)
-    newAcceptedRequests.add(conversationId)
-    saveStringSet('xmtp_accepted_requests', newAcceptedRequests)
-    set({ acceptedRequests: newAcceptedRequests })
+  acceptRequest: async (conversationId: string) => {
+    try {
+      await xmtpService.setConsentState(conversationId, ConsentState.Allowed)
+      set((state) => ({
+        conversations: state.conversations.map((c) =>
+          c.id === conversationId ? { ...c, consentState: 'allowed' } : c
+        )
+      }))
+    } catch (error) {
+      console.error('Failed to accept request:', error)
+    }
+  },
+
+  denyRequest: async (conversationId: string) => {
+    try {
+      await xmtpService.setConsentState(conversationId, ConsentState.Denied)
+      set((state) => ({
+        conversations: state.conversations.filter((c) => c.id !== conversationId),
+        selectedConversationId:
+          state.selectedConversationId === conversationId ? null : state.selectedConversationId
+      }))
+    } catch (error) {
+      console.error('Failed to block conversation:', error)
+    }
   },
 
   clearError: () => set({ error: null }),
@@ -865,10 +880,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // Clear message insertion queues
     messageInsertionQueues.clear()
 
-    // Clear localStorage for user-specific data
-    localStorage.removeItem('xmtp_accepted_requests')
-    localStorage.removeItem('xmtp_initiated_conversations')
-
     set({
       conversations: [],
       messages: new Map(),
@@ -878,9 +889,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isCreating: false,
       isSending: false,
       error: null,
-      unreadTotal: 0,
-      acceptedRequests: new Set(),
-      initiatedConversations: new Set()
+      unreadTotal: 0
     })
   }
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface ChatConversation {
   groupDescription?: string
   groupImageUrl?: string
   groupMembers?: string[]
+  consentState: 'unknown' | 'allowed' | 'denied'
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary

- Replace homegrown localStorage-based request system (`acceptedRequests`, `initiatedConversations`) with XMTP's native consent states
- Consent decisions now sync across all XMTP clients and properly handle group chats
- Add Block button to message requests view

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | Add `consentState` field to `ChatConversation` |
| `src/services/xmtp.ts` | Add `setConsentState()` method, re-export `ConsentState` |
| `src/stores/chatStore.ts` | Core consent integration — read consent state during load, filter denied, auto-allow followed users, async accept/deny, remove localStorage sets |
| `src/hooks/useConversations.ts` | Simplify `isPrimaryConversation` to consent-state check, remove `followingDids` dependency |
| `src/components/conversation/context/ConversationContext.ts` | Add `denyRequest` action |
| `src/components/conversation/ConversationProviderBridge.tsx` | Pass `denyRequest` through context |
| `src/components/chat/RequestsView.tsx` | Add Block button next to Accept/View |
| `src/stores/chatStore.test.ts` | Update tests for consent-based state, add accept/deny tests |

## What was broken before

- `acceptRequest()` only wrote to localStorage, never told XMTP
- `createDm()`/`createGroup()` tracked initiation in localStorage, not XMTP consent
- Groups always went to primary inbox (hardcoded `return true`)
- No deny/block capability
- Consent decisions were local-only, didn't sync across XMTP clients

## Test plan

- [x] `npm run typecheck` — no new TS errors (only pre-existing `app.dock` warnings)
- [x] `npm test` — all 87 tests pass
- [ ] Manual: DMs from followed users → primary inbox (auto-allowed)
- [ ] Manual: DMs from non-followed users → requests
- [ ] Manual: Group chats from others → requests (no longer hardcoded to primary)
- [ ] Manual: Accept a request → moves to primary
- [ ] Manual: Block a request → disappears
- [ ] Manual: Create a DM/group → appears in primary immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)