### PR TITLE
fix: resolve infinite "Checking..." spinner in updater

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,4 +38,6 @@ linux:
   category: Network
 publish:
   provider: github
+  owner: xmtplabs
+  repo: bluesky-chat
 generateUpdatesFilesForAllChannels: true

--- a/electron/services/updater.ts
+++ b/electron/services/updater.ts
@@ -147,10 +147,14 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
   })
 
   autoUpdater.on('error', (error: Error) => {
-    // Only send errors for user-initiated actions, not background checks
-    // Also ignore 404 errors (release not found = no update available)
-    if (!mainWindow?.isDestroyed() && isUserInitiatedCheck && !error.message.includes('404')) {
-      mainWindow.webContents.send('update-error', error.message)
+    if (!mainWindow?.isDestroyed()) {
+      if (isUserInitiatedCheck && !error.message.includes('404')) {
+        mainWindow.webContents.send('update-error', error.message)
+      } else {
+        // Reset renderer status for suppressed errors (background checks, 404s)
+        // so the UI doesn't get stuck on "Checking..."
+        mainWindow.webContents.send('update-not-available')
+      }
     }
   })
 


### PR DESCRIPTION
## Summary
- Background update check errors were silently swallowed without resetting the renderer status, leaving the UI permanently stuck on "Checking..." with the retry button disabled
- Suppressed errors (background checks, 404s) now send `update-not-available` to reset the renderer back to idle
- Pinned explicit `owner`/`repo` in publish config so the update URL is deterministic and doesn't depend on git remote state at build time

## Test plan
- [ ] Kill network and launch packaged app — verify Settings shows "Up to date" (not stuck on "Checking...")
- [ ] Re-enable network, click "Check for Updates" — verify it completes normally
- [ ] Verify `app-update.yml` in packaged build contains `owner: xmtplabs` and `repo: bluesky-chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)