### PR TITLE
fix: persist Bluesky session and XMTP installation across restarts

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -32,7 +32,11 @@ export default defineConfig({
     },
     server: {
       // Listen on 127.0.0.1 for AT Protocol OAuth loopback compatibility
-      host: '127.0.0.1'
+      host: '127.0.0.1',
+      // Fail instead of silently picking another port — a port change means a
+      // different origin, which wipes all origin-scoped storage (localStorage,
+      // IndexedDB, OPFS) and forces a full re-login + new XMTP installation.
+      strictPort: true
     },
     build: {
       rollupOptions: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, Menu, Notification, shell, nativeImage, protocol, net } from 'electron'
 import { join } from 'path'
 import { pathToFileURL } from 'url'
+import { existsSync, readdirSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 
 const iconPath = join(__dirname, '../../build/icon.png')
@@ -359,6 +360,23 @@ function createApplicationMenu(): void {
   Menu.setApplicationMenu(menu)
 }
 
+// Single instance lock — prevent multiple instances from fighting over storage locks.
+// When two instances share the same userData, the second one can't acquire LevelDB/SQLite
+// locks, causing all origin-scoped storage (localStorage, IndexedDB, OPFS) to fail.
+const gotTheLock = app.requestSingleInstanceLock()
+if (!gotTheLock) {
+  console.log('[main] Another instance is already running — quitting.')
+  app.quit()
+} else {
+  app.on('second-instance', () => {
+    // Focus the existing window when a second instance tries to launch
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+    }
+  })
+}
+
 // App lifecycle
 app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.bluesky.chat')
@@ -428,6 +446,28 @@ if (process.defaultApp) {
 function setupIpcHandlers(): void {
   // Build mode
   ipcMain.handle('get-build-mode', () => buildMode)
+
+  // Storage diagnostics
+  ipcMain.handle('get-storage-diagnostics', async () => {
+    const userDataPath = app.getPath('userData')
+    const secureStoragePath = join(userDataPath, 'secure-storage')
+    let secureStorageFiles: string[] = []
+    try {
+      if (existsSync(secureStoragePath)) {
+        secureStorageFiles = readdirSync(secureStoragePath).map(f => String(f))
+      }
+    } catch {
+      // ignore
+    }
+    return {
+      userDataPath,
+      secureStorageFiles,
+      electronVersion: process.versions.electron,
+      chromiumVersion: process.versions.chrome,
+      appName: app.getName(),
+      appPath: app.getAppPath()
+    }
+  })
 
   // Secure storage - only allow XMTP wallet keys
   const ALLOWED_STORAGE_KEY_PREFIX = 'xmtp-wallet-key-'

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,9 @@ import type { ElectronAPI } from '../src/types'
 const electronAPI: ElectronAPI = {
   // Build mode
   getBuildMode: () => ipcRenderer.invoke('get-build-mode'),
+  // Storage diagnostics
+  getStorageDiagnostics: () => ipcRenderer.invoke('get-storage-diagnostics'),
+
   // Secure storage
   secureStore: (key: string, value: string) => ipcRenderer.invoke('secure-store', key, value),
   secureRetrieve: (key: string) => ipcRenderer.invoke('secure-retrieve', key),

--- a/src/services/bluesky.ts
+++ b/src/services/bluesky.ts
@@ -32,18 +32,32 @@ class BlueskyService {
         redirectUri = 'http://127.0.0.1/oauth/callback'
       }
 
+      console.log('[bluesky] OAuth init - protocol:', loc.protocol, 'redirectUri:', redirectUri)
+
       const clientId = buildAtprotoLoopbackClientId({
         scope: 'atproto transition:generic',
         redirect_uris: [redirectUri]
       })
+
+      // Check IndexedDB state BEFORE loading OAuth client
+      try {
+        const databases = await indexedDB.databases()
+        const oauthDb = databases.find(db => db.name === '@atproto-oauth-client')
+        console.log('[bluesky] IndexedDB @atproto-oauth-client exists:', !!oauthDb, oauthDb ? `(version ${oauthDb.version})` : '')
+      } catch (e) {
+        console.warn('[bluesky] Could not check IndexedDB:', e)
+      }
 
       this.oauthClient = await BrowserOAuthClient.load({
         clientId,
         handleResolver: 'https://bsky.social'
       })
 
+      console.log('[bluesky] OAuth client loaded successfully')
+
       // Try to restore existing session
-      await this.tryRestoreSession()
+      const restored = await this.tryRestoreSession()
+      console.log('[bluesky] Session restore result:', restored)
     } catch (error) {
       console.warn('OAuth client initialization failed:', error)
       console.warn('Error details:', error instanceof Error ? error.stack : error)
@@ -56,15 +70,30 @@ class BlueskyService {
     if (!this.oauthClient) return false
 
     try {
+      const storedSub = localStorage.getItem('@@atproto/oauth-client-browser(sub)')
+      console.log('[bluesky] Attempting session restore via oauthClient.init()...')
+      console.log('[bluesky] Stored sub (DID) in localStorage:', storedSub || 'NONE — this is why restore fails!')
       const result = await this.oauthClient.init()
+      console.log('[bluesky] oauthClient.init() returned:', {
+        hasResult: !!result,
+        hasSession: !!result?.session,
+        resultKeys: result ? Object.keys(result) : []
+      })
       if (result?.session) {
         this.session = result.session
         // Create Agent directly from OAuth session
         this.agent = new Agent(result.session)
+        console.log('[bluesky] Session restored successfully')
         return true
       }
+      console.log('[bluesky] No session to restore (init returned null/empty)')
     } catch (error) {
-      console.error('Failed to restore Bluesky session:', error)
+      console.error('[bluesky] Session restore FAILED:', error)
+      console.error('[bluesky] Error type:', error?.constructor?.name)
+      if (error instanceof Error) {
+        console.error('[bluesky] Error message:', error.message)
+        console.error('[bluesky] Error stack:', error.stack)
+      }
     }
 
     return false
@@ -114,8 +143,15 @@ class BlueskyService {
     const { session } = await this.oauthClient.callback(callbackParams)
     this.session = session
 
-    // Create Agent directly from OAuth session - this is the key fix!
-    // The Agent class accepts an OAuthSession and uses it for authenticated requests
+    // Save the sub (DID) to localStorage so initRestore() can find it on next launch.
+    // The BrowserOAuthClient.initCallback() normally does this, but our Electron flow
+    // uses a separate auth window + IPC, bypassing initCallback(). Without this,
+    // the OAuth client can't restore the session and the user must re-login every time.
+    // NOTE: This key is an internal detail of @atproto/oauth-client-browser@0.3.40.
+    // If the library changes this key, session restore will break. Pin or audit on upgrade.
+    localStorage.setItem('@@atproto/oauth-client-browser(sub)', session.sub)
+
+    // Create Agent directly from OAuth session
     this.agent = new Agent(session)
 
     // Fetch and return profile
@@ -432,6 +468,10 @@ class BlueskyService {
         console.error('Error logging out agent:', error)
       }
     }
+
+    // Clear the session sub from localStorage (the OAuth client's 'deleted' event
+    // should also do this, but clear explicitly for safety)
+    localStorage.removeItem('@@atproto/oauth-client-browser(sub)')
 
     this.agent = null
     this.session = null

--- a/src/services/xmtp.ts
+++ b/src/services/xmtp.ts
@@ -110,6 +110,163 @@ async function checkIndexedDbExists(): Promise<{ exists: boolean; dbName: string
 }
 
 /**
+ * Check OPFS (Origin Private File System) for XMTP database files.
+ * The XMTP browser SDK stores its SQLite database in OPFS, not IndexedDB.
+ */
+async function checkOpfsFiles(): Promise<{ available: boolean; files: string[]; error?: string }> {
+  try {
+    if (!navigator.storage?.getDirectory) {
+      return { available: false, files: [], error: 'OPFS API not available' }
+    }
+    const root = await navigator.storage.getDirectory()
+    const files: string[] = []
+    // @ts-expect-error - entries() exists on FileSystemDirectoryHandle but TS types may lag
+    for await (const [name] of root.entries()) {
+      files.push(name)
+    }
+    return { available: true, files }
+  } catch (error) {
+    return { available: false, files: [], error: String(error) }
+  }
+}
+
+/**
+ * Check the StorageManager persistence status
+ */
+async function checkStoragePersistence(): Promise<{ persisted: boolean; estimate?: { usage: number; quota: number } }> {
+  try {
+    const persisted = await navigator.storage?.persisted?.() ?? false
+    const estimate = await navigator.storage?.estimate?.()
+    return {
+      persisted,
+      estimate: estimate ? { usage: estimate.usage ?? 0, quota: estimate.quota ?? 0 } : undefined
+    }
+  } catch {
+    return { persisted: false }
+  }
+}
+
+const PERSISTENCE_MARKER_KEY = 'xmtp-persistence-marker'
+const PERSISTENCE_MARKER_VERSION_KEY = 'xmtp-persistence-marker-version'
+const IDB_PERSISTENCE_DB = 'xmtp-persistence-test'
+const OPFS_PERSISTENCE_MARKER = '.xmtp-persistence-marker'
+
+/**
+ * Check if OPFS data survived from the previous session.
+ * Writes a small marker file to OPFS that we check on the next launch.
+ * This is independent of the XMTP SDK — it tests raw OPFS persistence.
+ */
+async function checkOpfsPersistence(): Promise<{ survived: boolean; previousTimestamp: string | null; writeError?: string }> {
+  try {
+    if (!navigator.storage?.getDirectory) {
+      return { survived: false, previousTimestamp: null, writeError: 'OPFS API not available' }
+    }
+    const root = await navigator.storage.getDirectory()
+
+    // Read previous marker
+    let previousTimestamp: string | null = null
+    try {
+      const markerHandle = await root.getFileHandle(OPFS_PERSISTENCE_MARKER, { create: false })
+      const file = await markerHandle.getFile()
+      previousTimestamp = await file.text()
+    } catch {
+      // File doesn't exist — first launch or data was lost
+    }
+
+    // Write new marker for next launch
+    try {
+      const markerHandle = await root.getFileHandle(OPFS_PERSISTENCE_MARKER, { create: true })
+      const writable = await markerHandle.createWritable()
+      await writable.write(new Date().toISOString())
+      await writable.close()
+    } catch (writeErr) {
+      return { survived: previousTimestamp !== null, previousTimestamp, writeError: String(writeErr) }
+    }
+
+    return { survived: previousTimestamp !== null, previousTimestamp }
+  } catch (error) {
+    return { survived: false, previousTimestamp: null, writeError: String(error) }
+  }
+}
+const IDB_PERSISTENCE_STORE = 'markers'
+
+/**
+ * Check if localStorage survived from the previous session.
+ * Writes a marker that we check on the next launch.
+ */
+function checkLocalStoragePersistence(): { survived: boolean; previousTimestamp: string | null; previousVersion: string | null } {
+  const previousTimestamp = localStorage.getItem(PERSISTENCE_MARKER_KEY)
+  const previousVersion = localStorage.getItem(PERSISTENCE_MARKER_VERSION_KEY)
+
+  // Write new marker for next launch
+  localStorage.setItem(PERSISTENCE_MARKER_KEY, new Date().toISOString())
+  const currentVersion = import.meta.env.VITE_APP_VERSION ?? 'unknown'
+  localStorage.setItem(PERSISTENCE_MARKER_VERSION_KEY, currentVersion)
+
+  return {
+    survived: previousTimestamp !== null,
+    previousTimestamp,
+    previousVersion
+  }
+}
+
+/**
+ * Check if IndexedDB data survived from the previous session.
+ * Uses a dedicated test database to avoid interfering with app data.
+ */
+async function checkIndexedDbPersistence(): Promise<{ survived: boolean; previousTimestamp: string | null }> {
+  return new Promise((resolve) => {
+    try {
+      const request = indexedDB.open(IDB_PERSISTENCE_DB, 1)
+
+      request.onupgradeneeded = () => {
+        const db = request.result
+        if (!db.objectStoreNames.contains(IDB_PERSISTENCE_STORE)) {
+          db.createObjectStore(IDB_PERSISTENCE_STORE)
+        }
+      }
+
+      request.onsuccess = () => {
+        const db = request.result
+        // Read previous marker
+        const readTx = db.transaction(IDB_PERSISTENCE_STORE, 'readonly')
+        const store = readTx.objectStore(IDB_PERSISTENCE_STORE)
+        const getReq = store.get('timestamp')
+
+        getReq.onsuccess = () => {
+          const previousTimestamp = getReq.result ?? null
+
+          // Write new marker
+          const writeTx = db.transaction(IDB_PERSISTENCE_STORE, 'readwrite')
+          const writeStore = writeTx.objectStore(IDB_PERSISTENCE_STORE)
+          writeStore.put(new Date().toISOString(), 'timestamp')
+
+          writeTx.oncomplete = () => {
+            db.close()
+            resolve({ survived: previousTimestamp !== null, previousTimestamp })
+          }
+          writeTx.onerror = () => {
+            db.close()
+            resolve({ survived: previousTimestamp !== null, previousTimestamp })
+          }
+        }
+
+        getReq.onerror = () => {
+          db.close()
+          resolve({ survived: false, previousTimestamp: null })
+        }
+      }
+
+      request.onerror = () => {
+        resolve({ survived: false, previousTimestamp: null })
+      }
+    } catch {
+      resolve({ survived: false, previousTimestamp: null })
+    }
+  })
+}
+
+/**
  * Get previous installation info from localStorage for a specific inbox
  * Uses per-inbox keys so multi-user doesn't cause false "new installation" warnings
  */
@@ -259,9 +416,10 @@ function markSessionEnded(): void {
 }
 
 /**
- * Log startup diagnostics - call this early in app startup
+ * Log startup diagnostics - call this early in app startup.
+ * Now checks OPFS, localStorage persistence, storage quotas, and main process info.
  */
-export function logStartupDiagnostics(): void {
+export async function logStartupDiagnostics(): Promise<void> {
   const previousSession = checkPreviousSessionState()
   const previousInfo = getPreviousInstallationInfo()
   const currentOrigin = typeof window !== 'undefined' ? window.location.origin : 'unknown'
@@ -270,39 +428,86 @@ export function logStartupDiagnostics(): void {
   // Save current origin for next comparison
   localStorage.setItem(LAST_ORIGIN_KEY, currentOrigin)
 
-  verboseGroup('🚀 XMTP STARTUP DIAGNOSTICS')
+  // ── Section 1: Basic info (verbose — detail only needed for debugging) ──
+  verboseGroup('XMTP STARTUP DIAGNOSTICS')
   verboseLog('Timestamp:', new Date().toISOString())
   verboseLog('Environment:', XMTP_ENV)
   verboseLog('Build mode:', import.meta.env.MODE)
   verboseLog('Current origin:', currentOrigin)
-  verboseLog('Previous origin:', previousOrigin || 'none')
+  verboseLog('Current URL:', typeof window !== 'undefined' ? window.location.href : 'unknown')
+  verboseLog('Previous origin:', previousOrigin || 'none (FIRST LAUNCH OR STORAGE WIPED)')
 
-  // Check for origin (port) change - this is the main cause of lost installations in dev!
+  // ── Section 2: Persistence checks (always log — critical for diagnosing issues) ──
+  const persistenceCheck = checkLocalStoragePersistence()
+  if (!persistenceCheck.survived) {
+    console.error('[xmtp] localStorage DID NOT SURVIVE from previous session')
+  }
+
+  const idbCheck = await checkIndexedDbPersistence()
+  if (!idbCheck.survived) {
+    console.error('[xmtp] IndexedDB DID NOT SURVIVE from previous session')
+  }
+
+  const opfsCheck = await checkOpfsPersistence()
+  if (opfsCheck.writeError) {
+    console.error('[xmtp] OPFS WRITE FAILED:', opfsCheck.writeError)
+  } else if (!opfsCheck.survived) {
+    verboseLog('[xmtp] OPFS marker did not survive (first launch or data lost)')
+  }
+
+  // Log summary line always (one line, not a wall of text)
+  const ls = persistenceCheck.survived ? 'OK' : 'LOST'
+  const idb = idbCheck.survived ? 'OK' : 'LOST'
+  const opfs = opfsCheck.writeError ? 'ERROR' : opfsCheck.survived ? 'OK' : 'NEW'
+  console.log(`[xmtp] Storage persistence: localStorage=${ls} IndexedDB=${idb} OPFS=${opfs}`)
+
+  // ── Section 3: Origin change (always log — this causes data loss) ──
   if (previousOrigin && previousOrigin !== currentOrigin) {
-    verboseError('🔴 ORIGIN CHANGED (different port)')
-    verboseError(`   Previous: ${previousOrigin}`)
-    verboseError(`   Current:  ${currentOrigin}`)
-    verboseError('   IndexedDB is scoped to origin - this WILL create a new installation!')
-    verboseError('   💡 Fix: Use strictPort in vite config or kill the process using the old port')
+    console.error('[xmtp] ORIGIN CHANGED:', previousOrigin, '->', currentOrigin, '— storage will be lost!')
+  }
+
+  // ── Section 4+: Detailed info (verbose only) ──
+  const opfsResult = await checkOpfsFiles()
+  if (opfsResult.available && opfsResult.files.length > 0) {
+    verboseLog('OPFS files:', opfsResult.files.join(', '))
+  }
+
+  try {
+    const databases = await indexedDB.databases()
+    verboseLog('IndexedDB databases:', databases.map(db => `${db.name} (v${db.version})`).join(', ') || 'none')
+  } catch {
+    // ignore
+  }
+
+  const storageInfo = await checkStoragePersistence()
+  verboseLog('Storage persisted:', storageInfo.persisted)
+  if (storageInfo.estimate) {
+    verboseLog(`Storage usage: ${(storageInfo.estimate.usage / 1024 / 1024).toFixed(1)} MB / ${(storageInfo.estimate.quota / 1024 / 1024).toFixed(0)} MB`)
+  }
+
+  try {
+    const diag = await window.electronAPI?.getStorageDiagnostics?.()
+    if (diag) {
+      verboseLog('userData:', diag.userDataPath)
+      verboseLog('Electron:', diag.electronVersion, '/ Chromium:', diag.chromiumVersion)
+      verboseLog('Secure storage files:', diag.secureStorageFiles.length > 0
+        ? diag.secureStorageFiles.join(', ')
+        : 'NONE')
+    }
+  } catch {
+    // ignore
   }
 
   if (previousSession.wasActive) {
-    verboseWarn('⚠️ PREVIOUS SESSION DID NOT END GRACEFULLY')
-    verboseWarn('   Previous session started:', previousSession.startTime)
-    verboseWarn('   This could indicate a crash, force quit, or killed dev server')
-    verboseWarn('   (This alone should NOT cause a new installation - IndexedDB should persist)')
-  } else {
-    verboseLog('✅ Previous session ended gracefully')
+    verboseWarn('Previous session did not end gracefully (started:', previousSession.startTime, ')')
   }
 
-  verboseLog('Previous installation ID:', previousInfo.installationId?.slice(0, 16) + '...' || 'none')
-  verboseLog('Previous inbox ID:', previousInfo.inboxId?.slice(0, 16) + '...' || 'none')
-  verboseLog('Previous environment:', previousInfo.env || 'none')
+  verboseLog('Previous installation:', previousInfo.installationId?.slice(0, 16) + '...' || 'none')
+  verboseLog('Previous inbox:', previousInfo.inboxId?.slice(0, 16) + '...' || 'none')
+  verboseLog('Previous env:', previousInfo.env || 'none')
 
   if (previousInfo.env && previousInfo.env !== XMTP_ENV) {
-    verboseError('🔴 ENVIRONMENT MISMATCH DETECTED')
-    verboseError(`   Previous: ${previousInfo.env}, Current: ${XMTP_ENV}`)
-    verboseError('   This WILL create a new installation!')
+    console.error('[xmtp] Environment mismatch:', previousInfo.env, '->', XMTP_ENV)
   }
 
   verboseGroupEnd()
@@ -315,11 +520,17 @@ if (typeof window !== 'undefined') {
       getHistory: typeof getInstallationHistory
       printHistory: typeof printInstallationHistory
       logStartup: typeof logStartupDiagnostics
+      checkOpfs: typeof checkOpfsFiles
+      checkOpfsPersistence: typeof checkOpfsPersistence
+      checkPersistence: typeof checkStoragePersistence
     }
   }).xmtpDiagnostics = {
     getHistory: getInstallationHistory,
     printHistory: printInstallationHistory,
-    logStartup: logStartupDiagnostics
+    logStartup: logStartupDiagnostics,
+    checkOpfs: checkOpfsFiles,
+    checkOpfsPersistence: checkOpfsPersistence,
+    checkPersistence: checkStoragePersistence
   }
 
   // Try to mark session as ended on window close
@@ -431,6 +642,21 @@ class XMTPService {
       }
 
       logInstallationDiagnostics(diagnostics)
+
+      // Verify OPFS has the database file after client creation
+      const expectedDbFile = `xmtp-${XMTP_ENV}-${newInboxId}.db3`
+      const postConnectOpfs = await checkOpfsFiles()
+      if (postConnectOpfs.available) {
+        const hasDb = postConnectOpfs.files.some(f => f === expectedDbFile)
+        if (hasDb) {
+          verboseLog(`OPFS: Database file confirmed: ${expectedDbFile}`)
+        } else {
+          verboseWarn(`OPFS: Expected "${expectedDbFile}" not found. Files:`,
+            postConnectOpfs.files.length > 0 ? postConnectOpfs.files.join(', ') : 'NONE')
+        }
+      } else {
+        console.error('[xmtp] OPFS not available after client creation:', postConnectOpfs.error)
+      }
 
       // Save current installation info for next comparison
       saveInstallationInfo(newInstallationId, newInboxId)

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -23,7 +23,7 @@ vi.mock('../services/xmtp', () => ({
     }),
     disconnect: vi.fn().mockResolvedValue(undefined)
   },
-  logStartupDiagnostics: vi.fn()
+  logStartupDiagnostics: vi.fn().mockResolvedValue(undefined)
 }))
 
 vi.mock('../services/identity', () => ({

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -100,7 +100,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   initializeServices: async () => {
     // Log startup diagnostics first to detect crashes/ungraceful shutdowns
-    logStartupDiagnostics()
+    // Fire-and-forget — don't block initialization
+    logStartupDiagnostics().catch((err) => console.warn('Startup diagnostics failed:', err))
 
     set({ isLoading: true, error: null })
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,16 @@ export interface ElectronAPI {
   onOAuthCallback: (callback: (data: { code: string; state: string; iss?: string }) => void) => void
   removeOAuthCallback: () => void
 
+  // Storage diagnostics
+  getStorageDiagnostics: () => Promise<{
+    userDataPath: string
+    secureStorageFiles: string[]
+    electronVersion: string
+    chromiumVersion: string
+    appName: string
+    appPath: string
+  }>
+
   // Auto-updater
   updaterCheck: () => Promise<{ success: boolean; updateInfo?: UpdateInfo; error?: string }>
   updaterDownload: () => Promise<{ success: boolean; error?: string }>


### PR DESCRIPTION
## Summary

- **Single-instance lock** prevents multiple Electron instances from fighting over LevelDB/SQLite locks in the shared userData directory — this was silently wiping all origin-scoped storage (localStorage, IndexedDB, OPFS)
- **OAuth session restore fix** — our Electron OAuth flow bypasses `BrowserOAuthClient.initCallback()`, which normally saves the user's DID to localStorage. Without this key, `initRestore()` can't find the session on next launch. Now we write `@@atproto/oauth-client-browser(sub)` after `callback()` completes.
- **`strictPort: true`** in Vite config so dev fails loudly if port 5173 is taken instead of silently switching (which changes the origin and wipes storage)
- **Storage persistence diagnostics** — markers for localStorage, IndexedDB, and OPFS that check if data survived from the previous session. Single summary line in production, verbose detail in dev/beta.

## Root causes

| Problem | Cause | Fix |
|---------|-------|-----|
| Storage wiped on every restart | Multiple instances sharing userData → LevelDB LOCK conflict → Chromium resets quota DB | `app.requestSingleInstanceLock()` |
| Bluesky re-login every restart | `oauthClient.callback()` stores session in IndexedDB but doesn't save `sub` to localStorage; `initRestore()` needs that key to know which session to restore | `localStorage.setItem('@@atproto/oauth-client-browser(sub)', session.sub)` |
| Silent storage loss in dev | Vite picks next available port if 5173 is taken → different origin → different storage | `strictPort: true` |

## Test plan

- [ ] Dev: login → quit (Cmd+Q) → relaunch → verify session restores without re-login
- [ ] Dev: verify XMTP installation is REUSED (not NEW) across restarts
- [ ] Dev: run with port 5173 occupied → verify Vite fails instead of silently using 5174
- [ ] Prod: build → install → login → quit → relaunch → verify session restores
- [ ] Prod: verify diagnostics show single summary line (not verbose dump)
- [ ] Mixed: verify launching dev while prod is running shows "Another instance is already running" and quits

🤖 Generated with [Claude Code](https://claude.com/claude-code)