### PR TITLE
fix: resolve "Restart to Update" button doing nothing

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -37,7 +37,7 @@ const electronAPI: ElectronAPI = {
   // Auto-updater
   updaterCheck: () => ipcRenderer.invoke('updater:check'),
   updaterDownload: () => ipcRenderer.invoke('updater:download'),
-  updaterInstall: () => ipcRenderer.send('updater:install'),
+  updaterInstall: () => ipcRenderer.invoke('updater:install'),
   updaterGetBetaOptIn: () => ipcRenderer.invoke('updater:getBetaOptIn'),
   updaterSetBetaOptIn: (enabled: boolean) => ipcRenderer.invoke('updater:setBetaOptIn', enabled),
   onUpdateChecking: (callback: () => void) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,7 +110,7 @@ export interface ElectronAPI {
   // Auto-updater
   updaterCheck: () => Promise<{ success: boolean; updateInfo?: UpdateInfo; error?: string }>
   updaterDownload: () => Promise<{ success: boolean; error?: string }>
-  updaterInstall: () => void
+  updaterInstall: () => Promise<void>
   updaterGetBetaOptIn: () => Promise<boolean>
   updaterSetBetaOptIn: (enabled: boolean) => Promise<{ success: boolean }>
   onUpdateChecking: (callback: () => void) => void


### PR DESCRIPTION
## Summary
- Fixed the "Restart to Update" button being completely non-functional after downloading an update
- Root cause: `updaterInstall` in the preload bridge used `ipcRenderer.send()` (one-way, dispatches to `ipcMain.on()`) but the main process handler was registered with `ipcMain.handle()` (which only receives `ipcRenderer.invoke()` calls) — the message was silently dropped
- Changed `send` to `invoke` to match the handler registration, consistent with all other updater IPC calls

## Test plan
- [ ] Build packaged app, trigger an update download, click "Restart to Update" — app should quit and relaunch on the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)