### PR TITLE
fix: correct mapping service fallback URL for production builds

### DIFF
--- a/src/services/mappingBackend.ts
+++ b/src/services/mappingBackend.ts
@@ -9,7 +9,7 @@
  */
 
 // Backend URL - can be overridden via environment variable
-const BACKEND_URL = import.meta.env.VITE_MAPPING_BACKEND_URL ?? 'https://bluesky-chat-mapping-service.workers.dev'
+const BACKEND_URL = import.meta.env.VITE_MAPPING_BACKEND_URL ?? 'https://bluesky-chat-mapping-service.xmtp.workers.dev'
 
 // Circuit breaker configuration
 const CIRCUIT_BREAKER_THRESHOLD = 5 // Open after 5 consecutive failures


### PR DESCRIPTION
## Summary
- The hardcoded fallback URL in `mappingBackend.ts` was `bluesky-chat-mapping-service.workers.dev` instead of `bluesky-chat-mapping-service.xmtp.workers.dev`
- In dev, `.env.local` provides the correct URL, so it worked fine
- In production builds, the env var isn't set, so the fallback kicks in — hitting a nonexistent worker and silently failing

## Test plan
- [ ] Verify production build makes successful requests to the mapping service
- [ ] Confirm lookup and register calls return expected responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)