### PR TITLE
feat: show member names instead of "Group Chat" for unnamed groups

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -2,6 +2,7 @@ import { useChat } from './context/ChatContext'
 import { useUIStore } from '../../stores/uiStore'
 import { UserLockup } from '../shared/UserLockup'
 import { Avatar } from '../shared/Avatar'
+import { getGroupMemberNames } from '../../utils/format'
 
 /**
  * Chat header component - shows conversation name, avatar, and metadata
@@ -42,7 +43,7 @@ export function ChatHeader() {
 
   // For groups or DMs without profile, render manually
   const displayName = conversation.isGroup
-    ? conversation.groupName || 'Group Chat'
+    ? conversation.groupName || getGroupMemberNames(conversation.groupMembers)
     : conversation.peerProfile?.displayName ||
       conversation.peerProfile?.handle ||
       'Unknown'

--- a/src/components/chat/RequestsView.tsx
+++ b/src/components/chat/RequestsView.tsx
@@ -1,6 +1,7 @@
 import { useConversations } from '../../hooks/useConversations'
 import type { ChatConversation } from '../../types'
 import { Avatar } from '../shared/Avatar'
+import { getGroupMemberNames } from '../../utils/format'
 
 interface RequestsViewProps {
   onClose: () => void
@@ -104,7 +105,7 @@ interface RequestItemProps {
 
 function RequestItem({ conversation, onAccept, onView, onBlock }: RequestItemProps) {
   const displayName = conversation.isGroup
-    ? conversation.groupName || 'Group Chat'
+    ? conversation.groupName || getGroupMemberNames(conversation.groupMembers)
     : conversation.peerProfile?.displayName ||
       conversation.peerProfile?.handle ||
       shortenAddress(conversation.peerAddress)

--- a/src/components/chat/group-admin/variants/MetadataSection.tsx
+++ b/src/components/chat/group-admin/variants/MetadataSection.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useGroupAdmin } from '../context/GroupAdminContext'
 import { Avatar } from '../../../shared/Avatar'
+import { xmtpService } from '../../../../services/xmtp'
 
 const MAX_NAME_LENGTH = 64
 const MAX_DESCRIPTION_LENGTH = 256
@@ -17,7 +18,25 @@ export function MetadataSection() {
 
   const isEditing = editMode === 'edit-metadata'
   const currentImageUrl = draftImagePreview || group?.imageUrl
-  const displayName = group?.name || 'Group Chat'
+
+  // Generate fallback name from member profiles (excluding self)
+  const fallbackName = useMemo(() => {
+    const myInboxId = xmtpService.getInboxId()
+    const otherMembers = members.filter((m) => m.inboxId !== myInboxId)
+    if (otherMembers.length === 0) return 'Group Chat'
+
+    const names = otherMembers
+      .slice(0, 3)
+      .map((m) => m.profile?.displayName || m.profile?.handle || m.inboxId.slice(0, 8))
+
+    const remaining = otherMembers.length - names.length
+    if (remaining > 0) {
+      return `${names.join(', ')} +${remaining}`
+    }
+    return names.join(', ')
+  }, [members])
+
+  const displayName = group?.name || fallbackName
 
   const handleAvatarClick = () => {
     if (isEditing) {

--- a/src/components/conversation/ConversationItem.tsx
+++ b/src/components/conversation/ConversationItem.tsx
@@ -1,6 +1,7 @@
 import type { ChatConversation } from '../../types'
 import { useUIStore } from '../../stores/uiStore'
 import { Avatar } from '../shared/Avatar'
+import { getGroupMemberNames } from '../../utils/format'
 
 interface ConversationItemProps {
   conversation: ChatConversation
@@ -44,7 +45,7 @@ export function ConversationItem({ conversation, isSelected, onSelect }: Convers
   }
 
   const displayName = conversation.isGroup
-    ? conversation.groupName || 'Group Chat'
+    ? conversation.groupName || getGroupMemberNames(conversation.groupMembers)
     : conversation.peerProfile?.displayName ||
       conversation.peerProfile?.handle ||
       shortenAddress(conversation.peerAddress)

--- a/src/components/conversation/ConversationProviderBridge.tsx
+++ b/src/components/conversation/ConversationProviderBridge.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, type ReactNode } from 'react'
 import { ConversationProvider, type ConversationContextValue } from './context/ConversationContext'
 import { useConversations } from '../../hooks/useConversations'
+import { getGroupMemberNames } from '../../utils/format'
 
 interface ConversationProviderBridgeProps {
   children: ReactNode
@@ -31,7 +32,7 @@ export function ConversationProviderBridge({
     const query = searchQuery.toLowerCase()
     return conversations.filter((conv) => {
       const displayName = conv.isGroup
-        ? conv.groupName || 'Group Chat'
+        ? conv.groupName || getGroupMemberNames(conv.groupMembers)
         : conv.peerProfile?.displayName || ''
       const handle = conv.peerProfile?.handle || ''
       const lastMessage = conv.lastMessage || ''

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,6 @@
+import { identityService } from '../services/identity'
+import { xmtpService } from '../services/xmtp'
+
 /**
  * Format bytes into human-readable string
  */
@@ -5,4 +8,51 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * Get a display name for a group chat based on its members.
+ * Returns comma-separated member names (excluding current user), e.g., "Alice, Bob, Charlie"
+ * Falls back to "Group Chat" if no member profiles are available.
+ */
+export function getGroupMemberNames(memberInboxIds: string[] | undefined, maxNames = 3): string {
+  if (!memberInboxIds || memberInboxIds.length === 0) {
+    return 'Group Chat'
+  }
+
+  const myInboxId = xmtpService.getInboxId()
+  const otherMembers = memberInboxIds.filter((id) => id !== myInboxId)
+
+  if (otherMembers.length === 0) {
+    return 'Group Chat'
+  }
+
+  const names: string[] = []
+  for (const inboxId of otherMembers) {
+    if (names.length >= maxNames) break
+    const did = identityService.getDidFromInboxId(inboxId)
+    if (did) {
+      const profile = identityService.getCachedProfile(did)
+      if (profile) {
+        names.push(profile.displayName || profile.handle || inboxId.slice(0, 8))
+      } else {
+        // DID is resolved but profile isn't cached - use first 8 chars of inbox ID
+        names.push(inboxId.slice(0, 8))
+      }
+    } else {
+      // Inbox ID not resolved - use first 8 chars
+      names.push(inboxId.slice(0, 8))
+    }
+  }
+
+  if (names.length === 0) {
+    return 'Group Chat'
+  }
+
+  const remaining = otherMembers.length - names.length
+  if (remaining > 0) {
+    return `${names.join(', ')} +${remaining}`
+  }
+
+  return names.join(', ')
 }


### PR DESCRIPTION
## Summary
- Unnamed group chats now display comma-separated member names (e.g., "Alice, Bob, Charlie") instead of the generic "Group Chat" fallback
- Shows up to 3 member names with a "+N" suffix for larger groups (e.g., "Alice, Bob, Charlie +2")
- Excludes the current user from the displayed names

## Test plan
- [ ] Create a group chat without setting a name
- [ ] Verify the conversation list shows member names instead of "Group Chat"
- [ ] Verify the chat header shows member names
- [ ] Verify the group admin modal shows member names
- [ ] Test with groups of 1, 2, 3, and 4+ members

🤖 Generated with [Claude Code](https://claude.com/claude-code)