### PR TITLE
Display sender names in group chat messages

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -41,9 +41,18 @@ export function MessageBubble({ message, isOwn, showAvatar, avatar, groupPositio
 
   const isAvatarClickable = !isOwn && showAvatar && message.senderProfile?.did
 
+  const senderName = !isOwn && isGroupChat && showAvatar
+    ? (message.senderProfile?.displayName || message.senderProfile?.handle)
+    : undefined
+
   return (
     <div className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
       <div className={`flex flex-col max-w-[75%] ${isOwn ? 'items-end' : 'items-start'}`}>
+        {senderName && (
+          <span className="text-[12px] font-medium text-[var(--color-text-secondary)] ml-10 mb-0.5 truncate max-w-full">
+            {senderName}
+          </span>
+        )}
         <div className={`flex items-end gap-2 ${isOwn ? 'flex-row-reverse' : ''}`}>
           {!isOwn && showAvatar && (
             <div className="flex-shrink-0 mb-1">

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -18,6 +18,18 @@ const messageInsertionQueues = new Map<string, Promise<void>>()
 let loadConversationsToken: symbol | null = null
 
 /**
+ * Look up a sender's BlueskyProfile from the identity cache.
+ * Returns undefined if the inbox ID hasn't been resolved yet.
+ */
+function getSenderProfile(senderInboxId: string): BlueskyProfile | undefined {
+  const did = identityService.getDidFromInboxId(senderInboxId)
+  if (did) {
+    return identityService.getCachedProfile(did) || undefined
+  }
+  return undefined
+}
+
+/**
  * Get a display name for a sender inbox ID.
  * Tries to resolve from identity cache, falls back to truncated ID.
  */
@@ -267,6 +279,7 @@ function addStreamedMessage(
     id: message.id,
     conversationId,
     senderAddress: message.senderInboxId || '',
+    senderProfile: conv.isGroup ? getSenderProfile(message.senderInboxId || '') : undefined,
     content: parsed.content,
     sentAt: Number(message.sentAtNs) / 1_000_000,
     status: 'delivered',
@@ -553,6 +566,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
               id: msg.id,
               conversationId,
               senderAddress: msg.senderInboxId || '',
+              senderProfile: isGroup ? getSenderProfile(msg.senderInboxId || '') : undefined,
               content: parsed.content,
               sentAt: Number(msg.sentAtNs) / 1_000_000,
               status: 'sent',


### PR DESCRIPTION
## Summary
Add sender name display above messages in group chats to improve message attribution and readability when multiple participants are involved in a conversation.

## Changes
- **MessageBubble component**: Display sender name (display name or handle) above messages in group chats
  - Added conditional rendering of sender name with appropriate styling (12px, secondary text color)
  - Name only displays for received messages in group chats when avatar is shown
  - Includes truncation to prevent overflow

- **Chat store**: Populate `senderProfile` field for group chat messages
  - Created `getSenderProfile()` helper function to look up sender profiles from the identity cache
  - Updated message creation in `addStreamedMessage()` to include sender profile for group messages
  - Updated message creation in the sent messages handler to include sender profile for group messages
  - Profile lookup only performed for group chats to avoid unnecessary cache queries

## Implementation Details
- Sender profile is resolved from the identity service cache using the sender's inbox ID
- The sender name display respects the existing message layout and styling conventions
- Profile lookup is deferred to the store layer to keep the component logic clean

https://claude.ai/code/session_01UEZGnitSwjwZeagdd1uzJ5