### PR TITLE
Add macOS download button to README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,17 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Upload stable-named macOS download
+        if: runner.os == 'macOS'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          DMG="dist/Bluesky-Chat-${VERSION}-arm64.dmg"
+          if [ -f "$DMG" ]; then
+            cp "$DMG" dist/Bluesky-Chat-arm64.dmg
+            # Delete previous stable-named asset if it exists, then upload
+            gh release upload "$TAG" dist/Bluesky-Chat-arm64.dmg --repo "$GITHUB_REPOSITORY" --clobber
+          fi

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![XMTP SDK v6](https://img.shields.io/badge/xmtp--sdk-v6-orange)](https://xmtp.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
+[**Download for macOS**](https://github.com/xmtplabs/bluesky-chat/releases/latest/download/Bluesky-Chat-arm64.dmg)
+
 An open source reference app from [XMTP Labs](https://xmtp.org) demonstrating how to build secure messaging for Bluesky users.
 
 This app publishes XMTP signatures to the `org.xmtp.inbox` AT Protocol record to cryptographically bind Bluesky handles to XMTP inboxes, enabling end-to-end encrypted DMs and group chats for the Bluesky network.


### PR DESCRIPTION
## Summary
- Adds a **Download for macOS** link to the README pointing to a stable-named arm64 DMG
- Adds a release workflow step that uploads `Bluesky-Chat-arm64.dmg` (stable name) alongside the versioned artifact on each release
- Uses `gh release upload --clobber` so the stable name always maps to the latest version
- `/releases/latest` only resolves to published releases, so users always get a working download even while a new build is in progress

## Test plan
- [ ] Verify the workflow step syntax is correct by inspecting the YAML
- [ ] Confirm the manual upload to v1.0.11 works (done in this PR session)
- [ ] After merging, trigger a release and verify the stable-named DMG appears in the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)