### PR TITLE
docs: note bsky.social is the only supported PDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ Click "Login with Bluesky" to authenticate via OAuth. The app opens a window for
 
 Alternatively, create an [App Password](https://bsky.app/settings/app-passwords) and log in with your handle and app password.
 
+## Supported PDS
+
+Currently only `bsky.social` is supported as a PDS (Personal Data Server). PRs are welcome to add support for other federated AT Protocol instances.
+
 ## Troubleshooting
 
 ### "Identity mismatch" warning


### PR DESCRIPTION
## Summary
- Adds a "Supported PDS" section to the README noting that only `bsky.social` is currently supported
- Invites PRs to add support for other federated AT Protocol instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)