### PR TITLE
Fix group chat avatar alignment

### DIFF
--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -11,7 +11,7 @@ import type { ChatMessage, MessageGroupPosition } from '../../types'
 type MessageListItem =
   | { type: 'security-banner' }
   | { type: 'date-divider'; timestamp: number }
-  | { type: 'message'; message: ChatMessage; isOwn: boolean; showAvatar: boolean; groupPosition: MessageGroupPosition; showTimestamp: boolean; isGroupChat: boolean }
+  | { type: 'message'; message: ChatMessage; isOwn: boolean; showAvatar: boolean; showSenderName: boolean; groupPosition: MessageGroupPosition; showTimestamp: boolean; isGroupChat: boolean }
 
 function canGroupMessages(current: ChatMessage, other: ChatMessage | null): boolean {
   if (!other) return false
@@ -68,11 +68,12 @@ export function ChatMessageList() {
       const isOwn = message.senderAddress === inboxId
       const groupPosition = getGroupPosition(messages, index)
       const isGroupChat = !!conversation?.isGroup
-      // Only show avatars in group chats, not DMs
-      const showAvatar = !isOwn && isGroupChat && (groupPosition === 'first' || groupPosition === 'single')
+      // Show avatar at bottom of group, sender name at top
+      const showAvatar = !isOwn && isGroupChat && (groupPosition === 'last' || groupPosition === 'single')
+      const showSenderName = !isOwn && isGroupChat && (groupPosition === 'first' || groupPosition === 'single')
       const showTimestamp = groupPosition === 'last' || groupPosition === 'single'
 
-      items.push({ type: 'message', message, isOwn, showAvatar, groupPosition, showTimestamp, isGroupChat })
+      items.push({ type: 'message', message, isOwn, showAvatar, showSenderName, groupPosition, showTimestamp, isGroupChat })
     })
 
     return items
@@ -116,6 +117,7 @@ export function ChatMessageList() {
               message={item.message}
               isOwn={item.isOwn}
               showAvatar={item.showAvatar}
+              showSenderName={item.showSenderName}
               avatar={item.isOwn ? myProfile?.avatar : (item.isGroupChat ? item.message.senderProfile?.avatar : conversation?.peerProfile?.avatar)}
               groupPosition={item.groupPosition}
               showTimestamp={item.showTimestamp}

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -5,6 +5,7 @@ interface MessageBubbleProps {
   message: ChatMessage
   isOwn: boolean
   showAvatar: boolean
+  showSenderName?: boolean
   avatar?: string
   groupPosition: MessageGroupPosition
   showTimestamp?: boolean
@@ -26,7 +27,7 @@ function getBubbleRadius(isOwn: boolean, pos: MessageGroupPosition): string {
   return 'rounded-2xl rounded-tl-md' // last
 }
 
-export function MessageBubble({ message, isOwn, showAvatar, avatar, groupPosition, showTimestamp = true, isGroupChat = false }: MessageBubbleProps) {
+export function MessageBubble({ message, isOwn, showAvatar, showSenderName = false, avatar, groupPosition, showTimestamp = true, isGroupChat = false }: MessageBubbleProps) {
   const { openUserProfile } = useUIStore()
   const time = new Date(message.sentAt).toLocaleTimeString(undefined, {
     hour: 'numeric',
@@ -41,7 +42,7 @@ export function MessageBubble({ message, isOwn, showAvatar, avatar, groupPositio
 
   const isAvatarClickable = !isOwn && showAvatar && message.senderProfile?.id
 
-  const senderName = !isOwn && isGroupChat && showAvatar
+  const senderName = !isOwn && isGroupChat && showSenderName
     ? (message.senderProfile?.displayName || message.senderProfile?.handle)
     : undefined
 
@@ -53,23 +54,23 @@ export function MessageBubble({ message, isOwn, showAvatar, avatar, groupPositio
             {senderName}
           </span>
         )}
-        <div className={`flex items-end gap-2 ${isOwn ? 'flex-row-reverse' : ''}`}>
+        <div className={`flex gap-2 ${isOwn ? 'flex-row-reverse' : ''}`}>
           {!isOwn && showAvatar && (
-            <div className="flex-shrink-0 mb-1">
+            <div className={`flex-shrink-0 self-stretch flex ${groupPosition === 'last' ? 'items-start' : 'items-end'}`}>
               {isAvatarClickable ? (
                 <button
                   onClick={handleAvatarClick}
                   aria-label="View profile"
-                  className="focus:outline-none focus:ring-2 focus:ring-[var(--color-bsky-500)] focus:ring-offset-2 rounded-full"
+                  className="p-0 leading-none focus:outline-none focus:ring-2 focus:ring-[var(--color-bsky-500)] focus:ring-offset-2 rounded-full"
                 >
                   {avatar ? (
-                    <img src={avatar} alt="" width={32} height={32} className="w-8 h-8 rounded-full hover:opacity-80 transition-opacity" />
+                    <img src={avatar} alt="" width={32} height={32} className="block w-8 h-8 rounded-full hover:opacity-80 transition-opacity" />
                   ) : (
                     <div className="w-8 h-8 rounded-full bg-[var(--color-surface-tertiary)] hover:opacity-80 transition-opacity" />
                   )}
                 </button>
               ) : avatar ? (
-                <img src={avatar} alt="" width={32} height={32} className="w-8 h-8 rounded-full" />
+                <img src={avatar} alt="" width={32} height={32} className="block w-8 h-8 rounded-full" />
               ) : (
                 <div className="w-8 h-8 rounded-full bg-[var(--color-surface-tertiary)]" />
               )}


### PR DESCRIPTION
## Summary
- Move avatar from first to last message in a group so chat bubbles visually rise from the avatar
- Avatar bottom-aligns with the bubble for single messages, top-aligns for the last message in a group
- Add separate `showSenderName` prop to keep sender label at the top of the group independently of avatar position
- Fix inline image baseline spacing and button padding that caused subtle misalignment

## Test plan
- [ ] Open a group chat with multiple messages from the same sender
- [ ] Verify avatar appears on the last message in a group (not the first)
- [ ] Verify single messages show avatar bottom-aligned with the bubble
- [ ] Verify sender name still appears above the first message in a group
- [ ] Verify DM conversations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)