### PR TITLE
Fix date separators not showing in chat history

### DIFF
--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -37,8 +37,7 @@ function getGroupPosition(messages: ChatMessage[], index: number): MessageGroupP
 }
 
 function shouldShowDateDivider(currentMessage: ChatMessage, prevMessage: ChatMessage | null): boolean {
-  if (!prevMessage) return false
-  if (prevMessage.isSystemMessage) return false
+  if (!prevMessage) return true
 
   const currentDate = new Date(currentMessage.sentAt).toDateString()
   const prevDate = new Date(prevMessage.sentAt).toDateString()

--- a/src/components/chat/DateDivider.tsx
+++ b/src/components/chat/DateDivider.tsx
@@ -26,11 +26,9 @@ export function DateDivider({ timestamp }: DateDividerProps) {
 
   return (
     <div className="flex items-center justify-center py-4">
-      <div className="px-3 py-1 bg-[var(--color-surface-secondary)] rounded-full">
-        <span className="text-[12px] font-medium text-[var(--color-text-secondary)]">
-          {dateLabel}
-        </span>
-      </div>
+      <span className="text-[12px] font-medium text-[var(--color-text-secondary)]">
+        {dateLabel}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Date dividers were never shown for the first message in a conversation (no "Today" header)
- System messages (e.g. "added you") suppressed the date comparison entirely, hiding dividers after them
- Styled date dividers as plain centered text instead of pill shape to differentiate from system messages

## Test plan
- [ ] Open a conversation — "Today" (or appropriate date) should appear above the first message
- [ ] Conversations spanning multiple days should show date dividers between days
- [ ] Date dividers after system messages should appear correctly when dates differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)