### PR TITLE
Fix stable-named DMG not uploading to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,10 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
-          DMG="dist/Bluesky-Chat-${VERSION}-arm64.dmg"
-          if [ -f "$DMG" ]; then
+          # electron-builder uses productName "Bluesky Chat" (with space) for local files
+          # but converts to hyphens when uploading to GitHub releases
+          DMG=$(ls dist/Bluesky*Chat*${VERSION}*arm64.dmg 2>/dev/null | head -1)
+          if [ -n "$DMG" ]; then
             cp "$DMG" dist/Bluesky-Chat-arm64.dmg
-            # Delete previous stable-named asset if it exists, then upload
             gh release upload "$TAG" dist/Bluesky-Chat-arm64.dmg --repo "$GITHUB_REPOSITORY" --clobber
           fi


### PR DESCRIPTION
## Summary
- The release workflow's stable-named DMG upload step was silently failing because electron-builder names local files with a space (`Bluesky Chat-...`) while the script looked for a hyphen (`Bluesky-Chat-...`)
- Uses a glob to find the DMG regardless of space/hyphen naming

## Test plan
- [ ] Merge and tag a new release, verify `Bluesky-Chat-arm64.dmg` appears in the release assets
- [ ] Verify https://github.com/xmtplabs/bluesky-chat/releases/latest/download/Bluesky-Chat-arm64.dmg resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)