### PR TITLE
Fix group chat message bubble alignment shift

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -76,7 +76,7 @@ export function MessageBubble({ message, isOwn, showAvatar, showSenderName = fal
               )}
             </div>
           )}
-          {!isOwn && !showAvatar && isGroupChat && <div className="w-8" />}
+          {!isOwn && !showAvatar && isGroupChat && <div className="w-8 flex-shrink-0" />}
 
           <div
             className={`px-4 py-2.5 ${getBubbleRadius(isOwn, groupPosition)} ${


### PR DESCRIPTION
## Summary
- Add `flex-shrink-0` to the avatar spacer div in `MessageBubble` for non-avatar messages in group chats
- The spacer was shrinking when bubble content was wide, causing inconsistent left-edge alignment across grouped messages (a stair-step/nesting effect)
- The avatar container already had `flex-shrink-0` but the spacer used for non-avatar positions in the group was missing it

## Test plan
- [ ] Open a group chat with multiple consecutive messages from another user
- [ ] Verify all bubbles in the group have consistent left-edge alignment regardless of content width

🤖 Generated with [Claude Code](https://claude.com/claude-code)